### PR TITLE
Deselect all deselects only shown items

### DIFF
--- a/lib/components/filtered-checklist.jsx
+++ b/lib/components/filtered-checklist.jsx
@@ -39,7 +39,7 @@ var FilteredChecklist = React.createClass({
         count ++;
         var checked = this.isChecked(opt);
         return (<ChecklistItem count={count} label={opt.label} checked={checked} value={opt.value} onChange={this.props.onChange} />);
-    }.bind(this));
+    }, this);
     
   },
   getItemsCheckedGroupBy: function(sortGroupsDescending) {
@@ -49,7 +49,7 @@ var FilteredChecklist = React.createClass({
                         .sort(null, sortGroupsDescending)
                         .toArray();
     var checkListItems = uniqueGroups.map(function(group) {
-      var groupOptions = this.state.filteredOptions.filter(function(opt) {return opt[this.props.groupBy] === group;}.bind(this));
+      var groupOptions = this.state.filteredOptions.filter(function(opt) {return opt[this.props.groupBy] === group;}, this);
       var groupOptionElements= Lazy(groupOptions)
                                  .sortBy(this.itemSortBy("label"))
                                  .toArray()
@@ -58,7 +58,7 @@ var FilteredChecklist = React.createClass({
                                     return (
                                       <ChecklistItem label={opt.label} checked={checked} value={opt.value} onChange={this.props.onChange} />
                                     );
-                                  }.bind(this));
+                                  }, this);
       if(groupOptions.length > 0) {
         var heading = (<li className="rcm-group-heading">{group}</li>);
         groupOptionElements.splice(0, 0, heading);
@@ -66,7 +66,7 @@ var FilteredChecklist = React.createClass({
       
 
       return groupOptionElements;
-    }.bind(this));
+    }, this);
 
     return checkListItems;
   },

--- a/lib/react-compact-multiselect.jsx
+++ b/lib/react-compact-multiselect.jsx
@@ -59,7 +59,17 @@ var ReactCompactMultiselect = React.createClass({
     this.fireValueChange(currentValues.concat(allValues));
   },
   deselectAll: function() {
-    this.fireValueChange([]);
+    var filterValue = String(this.state.filterValue).toLowerCase();
+    var currentValues = this.state.value;
+
+    var filteredValues = this.props.options.filter(function(opt) {
+        return (String(opt.label).toLowerCase().indexOf(filterValue) > -1); 
+    })
+    .map(function(opt) {return opt.value;});
+
+    currentValues = currentValues.filter(function(opt) { return filteredValues.indexOf(opt) === -1});
+
+    this.fireValueChange(currentValues);
   },
   fireValueChange: function(newValueState) {
     //value can change from the check boxes, or from the select all type buttons

--- a/lib/react-compact-multiselect.jsx
+++ b/lib/react-compact-multiselect.jsx
@@ -67,7 +67,7 @@ var ReactCompactMultiselect = React.createClass({
     })
     .map(function(opt) {return opt.value;});
 
-    currentValues = currentValues.filter(function(opt) { return filteredValues.indexOf(opt) === -1});
+    currentValues = currentValues.filter(function(opt) { return filteredValues.indexOf(opt) === -1; });
 
     this.fireValueChange(currentValues);
   },

--- a/lib/react-compact-multiselect.jsx
+++ b/lib/react-compact-multiselect.jsx
@@ -48,12 +48,15 @@ var ReactCompactMultiselect = React.createClass({
   },
   selectAll: function() {
     var filterValue = String(this.state.filterValue).toLowerCase();
+    var currentValues = this.state.value;
+
     var allValues = this.props.options.filter(function(opt) {
         return (String(opt.label).toLowerCase().indexOf(filterValue) > -1); 
     })
-    .map(function(opt) {return opt.value;});
+    .map(function(opt) {return opt.value;})
+    .filter(function(opt) { return currentValues.indexOf(opt) === -1; });
 
-    this.fireValueChange(this.state.value.concat(allValues));
+    this.fireValueChange(currentValues.concat(allValues));
   },
   deselectAll: function() {
     this.fireValueChange([]);

--- a/lib/react-compact-multiselect.jsx
+++ b/lib/react-compact-multiselect.jsx
@@ -47,8 +47,13 @@ var ReactCompactMultiselect = React.createClass({
     this.fireValueChange(newValueState);
   },
   selectAll: function() {
-    var allValues = this.props.options.map(function(opt) {return opt.value;});
-    this.fireValueChange(allValues);
+    var filterValue = String(this.state.filterValue).toLowerCase();
+    var allValues = this.props.options.filter(function(opt) {
+        return (String(opt.label).toLowerCase().indexOf(filterValue) > -1); 
+    })
+    .map(function(opt) {return opt.value;});
+
+    this.fireValueChange(this.state.value.concat(allValues));
   },
   deselectAll: function() {
     this.fireValueChange([]);


### PR DESCRIPTION
BEFORE YOU MERGE THIS:

This PR also contains code from PR #24 and should stack with it (since it was branched directly off).

In addition to Select All only adding items that are shown, this makes Deselect only deselect items that are shown. I'm unsure how useful it would be, but it's logically consistent with the Select All changes, and I can see at least one person complaining about it.